### PR TITLE
Schema generation resiliency improvements

### DIFF
--- a/src/UmbracoDeliveryApiExtensions.UI/UmbracoDeliveryApiExtensions.UI.esproj
+++ b/src/UmbracoDeliveryApiExtensions.UI/UmbracoDeliveryApiExtensions.UI.esproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.VisualStudio.JavaScript.Sdk/0.5.126-alpha">
   <PropertyGroup>
     <StartupCommand>npm run dev</StartupCommand>
+    <CleanCommand>npm run clean</CleanCommand>
     <ShouldRunNpmBuildScript>false</ShouldRunNpmBuildScript>
     <StaticWebAssetSourceId>Umbraco.Community.DeliveryApiExtensions</StaticWebAssetSourceId>
     <DebugAssetsDirectory>$(MSBuildProjectDirectory)\dist</DebugAssetsDirectory>

--- a/src/UmbracoDeliveryApiExtensions.UI/package.json
+++ b/src/UmbracoDeliveryApiExtensions.UI/package.json
@@ -8,6 +8,7 @@
     "dev:clean": "vite --force --base /",
     "build": "tsc && vite build",
     "watch": "chokidar src public -c \"tsc && vite build\" --initial",
+    "clean": "node -e \"['dist', 'obj', 'node_modules'].forEach(f => require('node:fs').rmSync(f, { recursive: true, force: true }))\"",
     "postinstall": "patch-package"
   },
   "dependencies": {

--- a/src/UmbracoDeliveryApiExtensions/Models/ContentTypePropertyInfo.cs
+++ b/src/UmbracoDeliveryApiExtensions/Models/ContentTypePropertyInfo.cs
@@ -11,6 +11,11 @@ public class ContentTypePropertyInfo
     public required string Alias { get; set; }
 
     /// <summary>
+    /// Property Editor alias.
+    /// </summary>
+    public required string EditorAlias { get; set; }
+
+    /// <summary>
     /// Property delivery api type.
     /// </summary>
     public required Type Type { get; set; }

--- a/src/UmbracoDeliveryApiExtensions/Services/ContentTypeInfoService.cs
+++ b/src/UmbracoDeliveryApiExtensions/Services/ContentTypeInfoService.cs
@@ -49,7 +49,7 @@ internal sealed class ContentTypeInfoService : IContentTypeInfoService
                 Alias = contentType.Alias,
                 SchemaId = GetContentTypeSchemaId(contentType),
                 CompositionSchemaIds = contentType.ContentTypeComposition.Select(GetContentTypeSchemaId).ToList(),
-                Properties = publishedContentType.PropertyTypes.Select(p => new ContentTypePropertyInfo { Alias = p.Alias, Type = p.DeliveryApiModelClrType, Inherited = !ownPropertyAliases.Contains(p.Alias) }).ToList(),
+                Properties = publishedContentType.PropertyTypes.Select(p => new ContentTypePropertyInfo { Alias = p.Alias, EditorAlias = p.EditorAlias, Type = p.DeliveryApiModelClrType, Inherited = !ownPropertyAliases.Contains(p.Alias) }).ToList(),
                 IsElement = contentType.IsElement,
                 IsComposition = false,
             });

--- a/src/UmbracoDeliveryApiExtensions/Swagger/DeliveryApiContentTypesSchemaFilter.cs
+++ b/src/UmbracoDeliveryApiExtensions/Swagger/DeliveryApiContentTypesSchemaFilter.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
@@ -17,6 +18,7 @@ public class DeliveryApiContentTypesSchemaFilter : ISchemaFilter, IDocumentFilte
     private readonly IOptionsMonitor<TypedSwaggerOptions> _typedSwaggerOptions;
     private readonly IContentTypeInfoService _contentTypeInfoService;
     private readonly ISchemaIdSelector _schemaIdSelector;
+    private readonly ILogger<DeliveryApiContentTypesSchemaFilter> _logger;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="DeliveryApiContentTypesSchemaFilter" /> class.
@@ -24,11 +26,13 @@ public class DeliveryApiContentTypesSchemaFilter : ISchemaFilter, IDocumentFilte
     public DeliveryApiContentTypesSchemaFilter(
         IOptionsMonitor<TypedSwaggerOptions> typedSwaggerOptions,
         IContentTypeInfoService contentTypeInfoService,
-        ISchemaIdSelector schemaIdSelector)
+        ISchemaIdSelector schemaIdSelector,
+        ILogger<DeliveryApiContentTypesSchemaFilter> logger)
     {
         _typedSwaggerOptions = typedSwaggerOptions;
         _contentTypeInfoService = contentTypeInfoService;
         _schemaIdSelector = schemaIdSelector;
+        _logger = logger;
     }
 
     /// <inheritdoc/>
@@ -242,7 +246,7 @@ public class DeliveryApiContentTypesSchemaFilter : ISchemaFilter, IDocumentFilte
         }
     }
 
-    private static OpenApiSchema ContentTypePropertiesMapper(ContentTypeInfo contentType, DocumentFilterContext context)
+    private OpenApiSchema ContentTypePropertiesMapper(ContentTypeInfo contentType, DocumentFilterContext context)
     {
         return context.SchemaRepository.AddDefinition(
             $"{contentType.SchemaId}PropertiesModel",
@@ -260,8 +264,20 @@ public class DeliveryApiContentTypesSchemaFilter : ISchemaFilter, IDocumentFilte
                         p => p.Alias,
                         p =>
                         {
-                            OpenApiSchema propertySchema = context.SchemaGenerator.GenerateSchema(p.Type, context.SchemaRepository);
-                            propertySchema.Nullable = true;
+                            OpenApiSchema propertySchema;
+                            try
+                            {
+                                propertySchema = context.SchemaGenerator.GenerateSchema(p.Type, context.SchemaRepository);
+                                propertySchema.Nullable = true;
+                            }
+                            catch (Exception ex)
+                            {
+                                // Just default to any type in case of error
+                                propertySchema = new OpenApiSchema();
+
+                                _logger.LogWarning(ex, "Failed to generate {PropertyType} schema of {PropertyEditorAlias} for property {PropertyAlias} of content type {ContentTypeAlias}", p.Type, p.EditorAlias, p.Alias, contentType.Alias);
+                            }
+
                             return propertySchema;
                         }
                     ),

--- a/tests/UmbracoDeliveryApiExtensions.TestSite/UmbracoDeliveryApiExtensions.TestSite.csproj
+++ b/tests/UmbracoDeliveryApiExtensions.TestSite/UmbracoDeliveryApiExtensions.TestSite.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <NoWarn>$(NoWarn),1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Umbraco.Cms" Version="13.0.1" />
+    <PackageReference Include="Umbraco.Cms" Version="13.5.2" />
     <PackageReference Include="uSync" Version="13.2.5" />
   </ItemGroup>
 

--- a/tests/UmbracoDeliveryApiExtensions.TestSite/delivery-compat.swagger.g.json
+++ b/tests/UmbracoDeliveryApiExtensions.TestSite/delivery-compat.swagger.g.json
@@ -1324,7 +1324,7 @@
           {
             "name": "fetch",
             "in": "query",
-            "description": "Specifies the media items to fetch. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Specifies the media items to fetch. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -1343,7 +1343,7 @@
           {
             "name": "filter",
             "in": "query",
-            "description": "Defines how to filter the fetched media items. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Defines how to filter the fetched media items. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "array",
               "items": {
@@ -1369,7 +1369,7 @@
           {
             "name": "sort",
             "in": "query",
-            "description": "Defines how to sort the found media items. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Defines how to sort the found media items. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "array",
               "items": {
@@ -1429,7 +1429,7 @@
           {
             "name": "expand",
             "in": "query",
-            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -1492,7 +1492,7 @@
           {
             "name": "fetch",
             "in": "query",
-            "description": "Specifies the media items to fetch. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Specifies the media items to fetch. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -1511,7 +1511,7 @@
           {
             "name": "filter",
             "in": "query",
-            "description": "Defines how to filter the fetched media items. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Defines how to filter the fetched media items. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "array",
               "items": {
@@ -1537,7 +1537,7 @@
           {
             "name": "sort",
             "in": "query",
-            "description": "Defines how to sort the found media items. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Defines how to sort the found media items. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "array",
               "items": {
@@ -1597,7 +1597,7 @@
           {
             "name": "expand",
             "in": "query",
-            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -1622,7 +1622,7 @@
           {
             "name": "fields",
             "in": "query",
-            "description": "Explicitly defines which properties should be included in the response (by default all properties are included). Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Explicitly defines which properties should be included in the response (by default all properties are included). Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -1696,7 +1696,7 @@
           {
             "name": "expand",
             "in": "query",
-            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -1760,7 +1760,7 @@
           {
             "name": "expand",
             "in": "query",
-            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -1831,7 +1831,7 @@
           {
             "name": "expand",
             "in": "query",
-            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -1856,7 +1856,7 @@
           {
             "name": "fields",
             "in": "query",
-            "description": "Explicitly defines which properties should be included in the response (by default all properties are included). Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Explicitly defines which properties should be included in the response (by default all properties are included). Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -1927,7 +1927,7 @@
           {
             "name": "expand",
             "in": "query",
-            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -1999,7 +1999,7 @@
           {
             "name": "expand",
             "in": "query",
-            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -2024,7 +2024,7 @@
           {
             "name": "fields",
             "in": "query",
-            "description": "Explicitly defines which properties should be included in the response (by default all properties are included). Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Explicitly defines which properties should be included in the response (by default all properties are included). Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -2098,7 +2098,7 @@
           {
             "name": "expand",
             "in": "query",
-            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -2123,7 +2123,7 @@
           {
             "name": "fields",
             "in": "query",
-            "description": "Explicitly defines which properties should be included in the response (by default all properties are included). Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Explicitly defines which properties should be included in the response (by default all properties are included). Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -2546,10 +2546,10 @@
           "propertyName": "contentType",
           "mapping": {
             "blockSettings": "#/components/schemas/BlockSettingsElementModel",
-            "testComposition": "#/components/schemas/TestCompositionElementModel",
-            "testComposition2": "#/components/schemas/TestComposition2ElementModel",
             "testBlock": "#/components/schemas/TestBlockElementModel",
-            "testBlock2": "#/components/schemas/TestBlock2ElementModel"
+            "testBlock2": "#/components/schemas/TestBlock2ElementModel",
+            "testComposition": "#/components/schemas/TestCompositionElementModel",
+            "testComposition2": "#/components/schemas/TestComposition2ElementModel"
           }
         }
       },

--- a/tests/UmbracoDeliveryApiExtensions.TestSite/delivery.swagger.g.json
+++ b/tests/UmbracoDeliveryApiExtensions.TestSite/delivery.swagger.g.json
@@ -1464,7 +1464,7 @@
           {
             "name": "fetch",
             "in": "query",
-            "description": "Specifies the media items to fetch. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Specifies the media items to fetch. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -1483,7 +1483,7 @@
           {
             "name": "filter",
             "in": "query",
-            "description": "Defines how to filter the fetched media items. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Defines how to filter the fetched media items. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "array",
               "items": {
@@ -1509,7 +1509,7 @@
           {
             "name": "sort",
             "in": "query",
-            "description": "Defines how to sort the found media items. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Defines how to sort the found media items. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "array",
               "items": {
@@ -1569,7 +1569,7 @@
           {
             "name": "expand",
             "in": "query",
-            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -1639,7 +1639,7 @@
           {
             "name": "fetch",
             "in": "query",
-            "description": "Specifies the media items to fetch. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Specifies the media items to fetch. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -1658,7 +1658,7 @@
           {
             "name": "filter",
             "in": "query",
-            "description": "Defines how to filter the fetched media items. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Defines how to filter the fetched media items. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "array",
               "items": {
@@ -1684,7 +1684,7 @@
           {
             "name": "sort",
             "in": "query",
-            "description": "Defines how to sort the found media items. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Defines how to sort the found media items. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "array",
               "items": {
@@ -1744,7 +1744,7 @@
           {
             "name": "expand",
             "in": "query",
-            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -1769,7 +1769,7 @@
           {
             "name": "fields",
             "in": "query",
-            "description": "Explicitly defines which properties should be included in the response (by default all properties are included). Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Explicitly defines which properties should be included in the response (by default all properties are included). Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -1850,7 +1850,7 @@
           {
             "name": "expand",
             "in": "query",
-            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -1914,7 +1914,7 @@
           {
             "name": "expand",
             "in": "query",
-            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -1992,7 +1992,7 @@
           {
             "name": "expand",
             "in": "query",
-            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -2017,7 +2017,7 @@
           {
             "name": "fields",
             "in": "query",
-            "description": "Explicitly defines which properties should be included in the response (by default all properties are included). Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Explicitly defines which properties should be included in the response (by default all properties are included). Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -2095,7 +2095,7 @@
           {
             "name": "expand",
             "in": "query",
-            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -2174,7 +2174,7 @@
           {
             "name": "expand",
             "in": "query",
-            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -2199,7 +2199,7 @@
           {
             "name": "fields",
             "in": "query",
-            "description": "Explicitly defines which properties should be included in the response (by default all properties are included). Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Explicitly defines which properties should be included in the response (by default all properties are included). Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -2280,7 +2280,7 @@
           {
             "name": "expand",
             "in": "query",
-            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Defines the properties that should be expanded in the response. Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -2305,7 +2305,7 @@
           {
             "name": "fields",
             "in": "query",
-            "description": "Explicitly defines which properties should be included in the response (by default all properties are included). Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#query-parameters) for more details on this.",
+            "description": "Explicitly defines which properties should be included in the response (by default all properties are included). Refer to [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api#query-parameters) for more details on this.",
             "schema": {
               "type": "string"
             },
@@ -2724,16 +2724,16 @@
             "$ref": "#/components/schemas/BlockSettingsElementModel"
           },
           {
-            "$ref": "#/components/schemas/TestCompositionElementModel"
-          },
-          {
-            "$ref": "#/components/schemas/TestComposition2ElementModel"
-          },
-          {
             "$ref": "#/components/schemas/TestBlockElementModel"
           },
           {
             "$ref": "#/components/schemas/TestBlock2ElementModel"
+          },
+          {
+            "$ref": "#/components/schemas/TestCompositionElementModel"
+          },
+          {
+            "$ref": "#/components/schemas/TestComposition2ElementModel"
           }
         ],
         "additionalProperties": false
@@ -2759,10 +2759,10 @@
           "propertyName": "contentType",
           "mapping": {
             "blockSettings": "#/components/schemas/BlockSettingsElementModel",
-            "testComposition": "#/components/schemas/TestCompositionElementModel",
-            "testComposition2": "#/components/schemas/TestComposition2ElementModel",
             "testBlock": "#/components/schemas/TestBlockElementModel",
-            "testBlock2": "#/components/schemas/TestBlock2ElementModel"
+            "testBlock2": "#/components/schemas/TestBlock2ElementModel",
+            "testComposition": "#/components/schemas/TestCompositionElementModel",
+            "testComposition2": "#/components/schemas/TestComposition2ElementModel"
           }
         }
       },


### PR DESCRIPTION
In case of exceptions during the schema generation of a specific property,
we now simply log it and return any type for the affected property.

Also updated the test website Umbraco version and added a cleanup action to the the UI project.