### PR TITLE
Make ContentTypePropertiesMapper public

### DIFF
--- a/src/UmbracoDeliveryApiExtensions/Swagger/DeliveryApiContentTypesSchemaFilter.cs
+++ b/src/UmbracoDeliveryApiExtensions/Swagger/DeliveryApiContentTypesSchemaFilter.cs
@@ -245,7 +245,7 @@ public class DeliveryApiContentTypesSchemaFilter : ISchemaFilter, IDocumentFilte
         }
     }
 
-    private OpenApiSchema ContentTypePropertiesMapper(ContentTypeInfo contentType, DocumentFilterContext context)
+    public OpenApiSchema ContentTypePropertiesMapper(ContentTypeInfo contentType, DocumentFilterContext context)
     {
         return context.SchemaRepository.AddDefinition(
             $"{contentType.SchemaId}PropertiesModel",


### PR DESCRIPTION
I'm just being oppertunistic here.

I'm working on a caching concept for Umbraco/Headless applications - and obviously I like typed deliver content, so I'm using your package. 

I am enriching all the content responses properties with "cachekeys", which allows the frontend to do proper caching and cache-invalidation on all relations in Umbraco. Ie. blog post has a writer-picker and the writer content is has the e-mail updated on the writer, now the frontend can invalidate the blog post that uses that writer without invalidating all the content.

See image
![image](https://github.com/user-attachments/assets/434ad70e-da9a-433b-bdbe-d101e6e321b9)

To have my added properties punch through to the frontend, I need them in swagger too, but your package clears the schema. 
If you'll allow this method to be public, I can  extend your class and override it without having to implement your entire DeliveryApiContentTypesSchemaFilter.cs which is what I currently have to do.

What I'm working on will eventually also result in a package, so again, just being oppertunistic and hoping this tiny change is harmless enough I can get away with it :)

This is a hugely useful and beneficial package regardles of whether you accept my PR, and it's much appreciated.
