### PR TITLE
Revert json viewer update

### DIFF
--- a/src/UmbracoDeliveryApiExtensions.UI/package-lock.json
+++ b/src/UmbracoDeliveryApiExtensions.UI/package-lock.json
@@ -11,7 +11,7 @@
         "@lit/context": "^1.1.6",
         "@lit/task": "^1.0.3",
         "@r2wc/react-to-web-component": "^2.1.0",
-        "@uiw/react-json-view": "^2.0.0-alpha.39",
+        "@uiw/react-json-view": "2.0.0-alpha.32",
         "lit": "^3.3.1",
         "preact": "^10.27.2"
       },
@@ -2321,9 +2321,9 @@
       }
     },
     "node_modules/@uiw/react-json-view": {
-      "version": "2.0.0-alpha.39",
-      "resolved": "https://registry.npmjs.org/@uiw/react-json-view/-/react-json-view-2.0.0-alpha.39.tgz",
-      "integrity": "sha512-D9MHNan56WhtdAsmjtE9x18YLY0JSMnh0a6Ji0/2sVXCF456ZVumYLdx2II7hLQOgRMa4QMaHloytpTUHxsFRw==",
+      "version": "2.0.0-alpha.32",
+      "resolved": "https://registry.npmjs.org/@uiw/react-json-view/-/react-json-view-2.0.0-alpha.32.tgz",
+      "integrity": "sha512-pGWaJLsc9vO0vOLHmffpKz5L5bOJLX+lfeLC32hXJfd6FSDjLD8LwSUyRLyFeYHezA8iFafvF2Vwm5+jADRrCw==",
       "license": "MIT",
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
@@ -4384,9 +4384,9 @@
       }
     },
     "node_modules/eslint-config-xo-typescript/node_modules/globals": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
-      "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/UmbracoDeliveryApiExtensions.UI/package.json
+++ b/src/UmbracoDeliveryApiExtensions.UI/package.json
@@ -14,7 +14,7 @@
     "@lit/context": "^1.1.6",
     "@lit/task": "^1.0.3",
     "@r2wc/react-to-web-component": "^2.1.0",
-    "@uiw/react-json-view": "^2.0.0-alpha.39",
+    "@uiw/react-json-view": "2.0.0-alpha.32",
     "lit": "^3.3.1",
     "preact": "^10.27.2"
   },


### PR DESCRIPTION
Since `@uiw/react-json-view` version `2.0.0-alpha.32` there have been changes to how the json data expansion works and in our case this is causing the data to always be collapsed, instead of using the configured collapsed level as previous.
I tried changing the configuration but with no luck, therefore I will simply cap the version for now to the one before the changes.