### PR TITLE
Expand nested properties up to 3 levels deep

### DIFF
--- a/src/UmbracoDeliveryApiExtensions.UI/src/contexts/api-preview.repository.ts
+++ b/src/UmbracoDeliveryApiExtensions.UI/src/contexts/api-preview.repository.ts
@@ -59,7 +59,7 @@ export class ApiPreviewRepository extends UmbControllerBase {
       params.headers.preview = 'true';
     }
 
-    const response = await fetch(`${this.#apiPath}/${type}/${uniqueId}${(expand ? '?expand=properties[$all]' : '')}`, params);
+    const response = await fetch(`${this.#apiPath}/${type}/${uniqueId}${(expand ? '?expand=properties[$all[properties[$all[properties[$all]]]]]' : '')}`, params);
     if (!response.ok) {
       throw new Error(response.statusText);
     }


### PR DESCRIPTION
## Summary

The expand toggle was sending `properties[$all]` which only expands top-level properties of the current content node. Properties of nested expandable items (content pickers, MNTP, block settings) were never expanded, causing the toggle to appear non-functional for nested content structures.

The fix uses a 3-level nested expansion string: `properties[$all[properties[$all[properties[$all]]]]]`, covering the current node → picked items → items inside picked items chain.

Fixes #93